### PR TITLE
Fix release file attachments

### DIFF
--- a/.github/workflows/master-pull-request-merge-reaction.yml
+++ b/.github/workflows/master-pull-request-merge-reaction.yml
@@ -56,13 +56,14 @@ jobs:
     name: Create GitHub release
     needs: [build_stex_release_windows, build_stex_release_linux, tag_master_and_sync_dev]
     if: github.event.pull_request.merged == true
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Download built Stex artifacts
       uses: actions/download-artifact@v3
       with:
         path: ${{ env.artifacts_path }}
     - name: Zip up release artifacts
+      shell: pwsh
       run: |
         $artifact_folders = Get-ChildItem -Directory -Path "${{ env.artifacts_path }}"
         foreach($art_dir in $artifact_folders)


### PR DESCRIPTION
softprops/action-gh-release globing doesn't support backslashes as directory separators and instead always treats them as the an escape character when a glob-based input under 'files' is detected.

Because of this, have the release job run on ubuntu so that the zip artifact directory path environment variable declared at the workflow level will resolve to a path with forward slashes, since environment variables are only evaluated at the job level.

See: https://github.com/softprops/action-gh-release/issues/280