### PR TITLE
Generate mip-maps down to 1x1

### DIFF
--- a/app/src/conversion.cpp
+++ b/app/src/conversion.cpp
@@ -66,18 +66,17 @@ QImage ToTexConverter::convertToBasePixelFormat()
 
 QVector<QImage> ToTexConverter::generateMipMaps(const QImage& baseImage)
 {
-    QVector<QImage> mipMaps;
-    QSize mipMapSize = baseImage.size()/2;
-
     // Ideally this would perform a bit more image processing but Qt doesn't have much
     // and for now the priority is to keep lib dependency low (ImageMagick feature disabling
     // on Windows in particular is really troublesome and it has a conflict with harfbuzz in Qt)
-    while(mipMapSize.width() > 0 && mipMapSize.height() > 0)
+
+    QVector<QImage> mipMaps;
+    QSize mipMapSize = baseImage.size();
+
+    while(mipMapSize != QSize(1,1))
     {
+        mipMapSize /= 2; // This always rounds up to the nearest integer, so it won't drop the dimensions below 1x1
         mipMaps.append(baseImage.scaled(mipMapSize, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
-        mipMapSize.setWidth(mipMapSize.width()/2);
-        mipMapSize.setHeight(mipMapSize.height()/2);
-        // Can't use QSize::operator/() directly because it rounds up to nearest integer and won't reach 0
     }
 
     return mipMaps;


### PR DESCRIPTION
This is how ztools and other KTEX tools handle mip-map generation. The previous approach only prepared mip-maps until one dimmension had a size of 1px.